### PR TITLE
Browser based token generator updated to 1.0.3.

### DIFF
--- a/NuGet/FCSAmerica.McGruff.TokenGenerator.BrowserBased.nuspec
+++ b/NuGet/FCSAmerica.McGruff.TokenGenerator.BrowserBased.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
     <metadata>
         <id>FCSAmerica.McGruff.TokenGenerator.BrowserBased</id>
-        <version>1.0.2</version>
+        <version>1.0.3</version>
         <title>FCSAmerica.McGruff.TokenGenerator.BrowserBased</title>
         <authors>Farm Credit Services of America</authors>
         <owners>Farm Credit Services of America</owners>

--- a/Source/FCSAmerica.McGruff.TokenGenerator/ServiceToken.cs
+++ b/Source/FCSAmerica.McGruff.TokenGenerator/ServiceToken.cs
@@ -111,6 +111,13 @@ namespace FCSAmerica.McGruff.TokenGenerator
             }
             set { _partnerName = value; }
         }
+        public DateTime TokenExpireDate
+        {
+            get
+            {
+                return _tokenExpireDate;
+            }
+        }
 
         private DateTime _tokenExpireDate = DateTime.MaxValue;
         protected string _token;
@@ -441,7 +448,7 @@ namespace FCSAmerica.McGruff.TokenGenerator
             }
         }
 
-        private void SetExpireDateFromToken()
+        protected void SetExpireDateFromToken()
         {
             XmlDocument samlToken = new XmlDocument();
             samlToken.LoadXml(_token);

--- a/Source/TokenGenerator.BrowserBased.IntegrationTests/BrowserBasedSecurityContextTests.cs
+++ b/Source/TokenGenerator.BrowserBased.IntegrationTests/BrowserBasedSecurityContextTests.cs
@@ -25,6 +25,66 @@ namespace FCSAmerica.McGruff.TokenGenerator.BrowserBased.IntegrationTests
 
         }
 
+        [Test]
+        public void BrowserBasedSecurityContext_WithForceInstanceFalse_GetsSameToken()
+        {
+            var ecsAddress = "http://devtitan.FCSAmerica.com/EnterpriseConfigurationStore/v1/RESTServices/api/ConfigItems";
+
+
+            var firstSecurityContext = BrowserBasedSecurityContext.GetInstance(ecsAddress, "DocIndexer", "FCSA", forceNewInstance: false);
+
+            Assert.IsNotNull(firstSecurityContext);
+            Assert.IsNotNull(firstSecurityContext.ServiceToken);
+            var firstRetrievedServiceToken = firstSecurityContext.ServiceToken;
+
+            Console.WriteLine("ApplicationName:" + firstSecurityContext.ApplicationName);
+            Console.WriteLine("PartnerName:" + firstSecurityContext.PartnerName);
+            Console.WriteLine("ServiceToken:" + firstSecurityContext.ServiceToken);
+
+
+            var secondSecurityContext = BrowserBasedSecurityContext.GetInstance(ecsAddress, "DocIndexer", "FCSA", forceNewInstance: false);
+
+            Assert.IsNotNull(secondSecurityContext);
+            Assert.IsNotNull(secondSecurityContext.ServiceToken);
+            var secondRetrievedServiceToken = secondSecurityContext.ServiceToken;
+
+            Assert.AreEqual(firstRetrievedServiceToken, secondRetrievedServiceToken);
+
+
+            Console.WriteLine("ServiceToken:" + secondSecurityContext.ServiceToken);
+
+
+
+        }
+
+        [Test]
+        public void BrowserBasedSecurityContext_WithForceInstanceTrue_GetsDifferentToken()
+        {
+            var ecsAddress = "http://devtitan.FCSAmerica.com/EnterpriseConfigurationStore/v1/RESTServices/api/ConfigItems";
+
+            var firstSecurityContext = BrowserBasedSecurityContext.GetInstance(ecsAddress, "DocIndexer", "FCSA", forceNewInstance: false);
+
+            Assert.IsNotNull(firstSecurityContext);
+            Assert.IsNotNull(firstSecurityContext.ServiceToken);
+            var firstRetrievedServiceToken = firstSecurityContext.ServiceToken;
+
+            Console.WriteLine("ApplicationName:" + firstSecurityContext.ApplicationName);
+            Console.WriteLine("PartnerName:" + firstSecurityContext.PartnerName);
+            Console.WriteLine("FirstServiceToken:" + firstSecurityContext.ServiceToken);
+
+
+            var secondSecurityContext = BrowserBasedSecurityContext.GetInstance(ecsAddress, "DocIndexer", "FCSA", forceNewInstance: true);
+
+            Assert.IsNotNull(secondSecurityContext);
+            Assert.IsNotNull(secondSecurityContext.ServiceToken);
+            var secondRetrievedServiceToken = secondSecurityContext.ServiceToken;
+
+            Assert.AreNotEqual(firstRetrievedServiceToken, secondRetrievedServiceToken);
+            Console.WriteLine("ApplicationName:" + secondSecurityContext.ApplicationName);
+            Console.WriteLine("PartnerName:" + secondSecurityContext.PartnerName);
+            Console.WriteLine("SecondServiceToken:" + secondSecurityContext.ServiceToken);
+        }
+
         [TestCase("FCSA")]
         [TestCase("NWFCS")]
         public void BrowserBasedSecurityContext_WithDocuClickProxyAddress_GetTokenAndAuditInfo(string partnerName)

--- a/Source/TokenGenerator.BrowserBased.IntegrationTests/BrowserBasedServiceTokenTests.cs
+++ b/Source/TokenGenerator.BrowserBased.IntegrationTests/BrowserBasedServiceTokenTests.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using NUnit.Framework;
+
+namespace FCSAmerica.McGruff.TokenGenerator.BrowserBased.IntegrationTests
+{
+    [TestFixture]
+    public class BrowserBasedServiceTokenTests
+    {
+        [Test]
+        public void BrowserBasedServiceToken_Defaults_ExpirationTimeToMaxValue()
+        {
+            var ecsAddress = "https://devinternal.fcsamerica.net/DocuClick/v3/REST/api/Proxy/EnterpriseConfigurationStore/v1/ConfigItems/";
+            var browserBasedToken = new BrowserBasedServiceToken(ecsAddress, "DocIndexer", "FCSA");
+
+            var tokenExpireDate = browserBasedToken.TokenExpireDate;
+
+            Console.WriteLine(tokenExpireDate);
+            Assert.AreEqual(DateTime.MaxValue, tokenExpireDate);
+        }
+
+        [Test]
+        public void BrowserBasedServiceToken_AfterTokenRetrieval_SetsTheExpirationTime()
+        {
+            var ecsAddress = "https://devinternal.fcsamerica.net/DocuClick/v3/REST/api/Proxy/EnterpriseConfigurationStore/v1/ConfigItems/";
+            var browserBasedToken = new BrowserBasedServiceToken(ecsAddress, "DocIndexer", "FCSA");
+
+            // Retrieve the token; this should set expiration date to something other than max value
+            var token = browserBasedToken.Token;
+
+            var tokenExpireDate = browserBasedToken.TokenExpireDate;
+            Console.WriteLine(tokenExpireDate);
+            Assert.IsTrue(tokenExpireDate < DateTime.MaxValue);
+        }
+    }
+}
+

--- a/Source/TokenGenerator.BrowserBased.IntegrationTests/TokenGenerator.BrowserBased.IntegrationTests.csproj
+++ b/Source/TokenGenerator.BrowserBased.IntegrationTests/TokenGenerator.BrowserBased.IntegrationTests.csproj
@@ -45,6 +45,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="BrowserBasedServiceTokenTests.cs" />
     <Compile Include="ServiceTokenTests.cs" />
     <Compile Include="BrowserBasedSecurityContextTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/Source/TokenGenerator.BrowserBased/BrowserBasedServiceToken.cs
+++ b/Source/TokenGenerator.BrowserBased/BrowserBasedServiceToken.cs
@@ -47,6 +47,7 @@ namespace FCSAmerica.McGruff.TokenGenerator.BrowserBased
                 _traceSource.TraceEvent(TraceEventType.Error, 0, "\nException occured during TokenRetriever RetrieveToken.\n" + UnwrapException(ex).ToString());
             }
 
+            SetExpireDateFromToken();
         }
 
         private Exception UnwrapException(Exception exception)


### PR DESCRIPTION
Browser based token generator updated to 1.0.3.
Bug fix:  Token was not properly expiring due to missing set expiration date call.